### PR TITLE
Implemented PWxyyy command

### DIFF
--- a/inc/motors.h
+++ b/inc/motors.h
@@ -21,6 +21,8 @@ extern void init_motors();
 
 extern void motor_set_speed_percent(motors_t motor_x, uint16_t speed, direction_t dir);
 
+extern void set_PWM(motors_t motor_x, uint16_t percent);
+
 extern int16_t motor_get_rpm(motors_t motor_x);
 
 extern void stop_all_motors();

--- a/src/FSM.c
+++ b/src/FSM.c
@@ -31,8 +31,8 @@
 #define PW_MOTOR_NUMBER_LOCATION	0x02
 #define PW_MOTOR_NUMBER_LENTGH		1
 #define PW_ARGUMENT_LOCATION		0x03
-#define PW_ARGUMENT_LENGTH			2
-#define PW_COMMAND_LENGTH			5
+#define PW_ARGUMENT_LENGTH			3
+#define PW_COMMAND_LENGTH			6
 
 // Stop Motor(SM) Command
 #define SM_MOTOR_NUMBER_LOCATION	0x02
@@ -216,7 +216,7 @@ extern void FSM(void *dummy){
 		else if(strncmp(commandString, "PW", 2) == 0 && strlen(commandString) == PW_COMMAND_LENGTH){
 
 			int8_t motorNumber = asciiToInt(commandString + PW_MOTOR_NUMBER_LOCATION, PW_MOTOR_NUMBER_LENTGH);
-			int8_t argument = asciiToInt(commandString + PW_ARGUMENT_LOCATION, PW_ARGUMENT_LENGTH);
+			int16_t argument = asciiToInt(commandString + PW_ARGUMENT_LOCATION, PW_ARGUMENT_LENGTH);
 
 			if (motorNumber < 1 || motorNumber > NUMBER_OF_MOTORS) {
 				// send out error: "Invalid motor number"
@@ -227,7 +227,7 @@ extern void FSM(void *dummy){
 				while(UART_push_out("ERR_ARG_IVD\r\n") == -2);
 
 			} else {
-				//Motor_PWM(motorNumber, (argument)* (10000 / 255));
+				set_PWM(motorNumber, argument);
 
 			}
 		}

--- a/src/motors.c
+++ b/src/motors.c
@@ -14,7 +14,10 @@
 #define INTERNAL_OSC_CALIB	1 // In case we decide to adjust for the manufacturing error in the internal clock
 
 //PWM Out Defines
-#define NEUTRAL		(3600)
+#define NEUTRAL				(3600)
+#define PWM_OUT_PRESCALER	(42 - 1)
+#define PWM_OUT_PERIOD		(40000 - 1)
+
 
 /* Global Variables
  * ----------------------------------------------------------
@@ -83,8 +86,8 @@ static void init_motor_pwm_out()
 
 	//timer set up
 	TIM_TimeBaseInitTypeDef TIM_TimeBaseStructure;
-	TIM_TimeBaseStructure.TIM_Period = (40000 - 1);
-	TIM_TimeBaseStructure.TIM_Prescaler = (42 - 1);
+	TIM_TimeBaseStructure.TIM_Period = PWM_OUT_PERIOD;
+	TIM_TimeBaseStructure.TIM_Prescaler = PWM_OUT_PRESCALER;
 	TIM_TimeBaseStructure.TIM_ClockDivision = 0;
 	TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;
 	TIM_TimeBaseStructure.TIM_RepetitionCounter = 0;
@@ -424,6 +427,42 @@ extern void motor_set_speed_percent(motors_t motor_x, uint16_t speed, direction_
 			break;
 	}
 
+}
+
+/**
+ * Sets the PWM out to the desired value
+ * param: percent: PWM duty cycle in 10^-1 percent
+ */
+extern void set_PWM(motors_t motor_x, uint16_t percent) {
+
+	uint32_t cc_value = ((percent * (PWM_OUT_PERIOD + 1)) / 1000);
+
+	switch(motor_x){
+		case Motor1:
+			TIM_SetCompare1(TIM2, cc_value);
+			break;
+		case Motor2:
+			TIM_SetCompare4(TIM2, cc_value);
+			break;
+		case Motor3:
+			TIM_SetCompare3(TIM1, cc_value);
+			break;
+		case Motor4:
+			TIM_SetCompare1(TIM1, cc_value);
+			break;
+		case Motor5:
+			TIM_SetCompare4(TIM4, cc_value);
+			break;
+		case Motor6:
+			TIM_SetCompare1(TIM4, cc_value);
+			break;
+		case Motor7:
+			TIM_SetCompare1(TIM3, cc_value);
+			break;
+		case Motor8:
+			TIM_SetCompare3(TIM3, cc_value);
+			break;
+	}
 }
 
 /* Poorna's section.


### PR DESCRIPTION
Implemented PWxyyy command. The ESC can be programmed using an python script using this command. The argument is in 10^-1 percent duty cycle. If no UART commands are sent to the Micro for 5 seconds, the  duty cycle will reset to 9 percent. I can add a feature to override this for programming the ESCs if needed. For now, the python script will need to send data to the micro at least every 5 seconds.